### PR TITLE
[maint] Organize errors for TimingParameters to include errors on the same line

### DIFF
--- a/fusi_bids_pydantic.py
+++ b/fusi_bids_pydantic.py
@@ -581,10 +581,15 @@ class TimingParameters(TimingParametersBase):
             else:
                 return self
 
-        raise ValueError(
-            "Timing parameters must conform to one of the defined options (A-E).\n"
-            "Validation failed for all timing-config options:\n - "
-            "\n - ".join(str(err) for err in errors)
+        # Raise a single error that includes all the line-errors
+        all_line_errors = []
+        for validation_error in errors:
+            line_errors = validation_error.errors()
+            all_line_errors.extend(line_errors)
+        raise ValidationError.from_exception_data(
+            title="TimingParameters: no valid timing option found (A-E)",
+            # This is a Python-Rust wrapper, so we need to ignore the type error
+            line_errors=all_line_errors,  # type: ignore[arg-type]
         )
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -293,6 +293,12 @@ def test_timing_options(timing_option_a_data, timing_options_common_data):
             **timing_options_common_data,
         })
 
+    # Test top-level validator
+    with pytest.raises(ValidationError, match="validation errors"):
+        TimingParameters.model_validate({
+            **timing_options_common_data,
+        })
+
 
 def test_task_information_validation(task_data):
     """Test TaskInformation model validation."""


### PR DESCRIPTION
New error message style:

```
E       pydantic_core._pydantic_core.ValidationError: 5 validation errors for TimingParameters
E         Value error, Invalid timing configuration for TimingOptionA: requires repetition_time_s [type=value_error, input_value={'SliceEncodingDirection'...DelayAfterTrigger': 0.5}, input_type=dict]
E           For further information visit https://errors.pydantic.dev/2.10/v/value_error
E         Value error, Invalid timing configuration for TimingOptionB: requires slice_timing_s, volume_timing_s [type=value_error, input_value={'SliceEncodingDirection'...DelayAfterTrigger': 0.5}, input_type=dict]
E           For further information visit https://errors.pydantic.dev/2.10/v/value_error
E         Value error, Invalid timing configuration for TimingOptionC: requires acquisition_duration_s, volume_timing_s [type=value_error, input_value={'SliceEncodingDirection'...DelayAfterTrigger': 0.5}, input_type=dict]
E           For further information visit https://errors.pydantic.dev/2.10/v/value_error
E         Value error, Invalid timing configuration for TimingOptionD: requires slice_timing_s, repetition_time_s [type=value_error, input_value={'SliceEncodingDirection'...DelayAfterTrigger': 0.5}, input_type=dict]
E           For further information visit https://errors.pydantic.dev/2.10/v/value_error
E         Value error, Invalid timing configuration for TimingOptionE: requires repetition_time_s [type=value_error, input_value={'SliceEncodingDirection'...DelayAfterTrigger': 0.5}, input_type=dict]
E           For further information visit https://errors.pydantic.dev/2.10/v/value_error
```